### PR TITLE
DPE-7166: Add spread tests and backward compatibility with legacy OCI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-name: Tests
+name: Rock Build/Tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,16 +12,46 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install tox
-        run: pipx install tox
-      - name: Run linters
-        run: tox run -e lint
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v32.1.0
 
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v32.2.0
+
+  test:
+    name: Test rock | ${{ matrix.base.version }} ${{ matrix.platform.arch }}
+    timeout-minutes: 10
+    # runs-on: [self-hosted, linux, "${{ matrix.platform.host_arch }}", "${{ matrix.base.codename }}", large]
+    runs-on: "ubuntu-${{ matrix.base.version }}${{ matrix.platform.gh_suffix }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        base:
+          - { codename: noble, version: 24.04 }
+        platform:
+          - { os: linux, arch: amd64, host_arch: x64, gh_suffix: "" }
+    needs:
+      - lint
+      - build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download rock package(s)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*-${{ matrix.platform.arch }}
+          merge-multiple: true
+      - name: Run tests
+        run: |
+          # lxd is necessary for spread
+          sudo snap install lxd
+          sudo adduser "$USER" lxd
+          # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxd waitready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxd init --auto
+          # Workaround for Docker & LXD on same machine
+          sudo iptables -F FORWARD
+          sudo iptables -P FORWARD ACCEPT
+
+          sudo snap install rockcraft --classic --edge
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- rockcraft test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,11 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v32.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v32.2.2
 
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v32.2.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v32.2.2
 
   test:
     name: Test rock | ${{ matrix.base.version }} ${{ matrix.platform.arch }}
@@ -30,6 +30,7 @@ jobs:
           - { codename: noble, version: 24.04 }
         platform:
           - { os: linux, arch: amd64, host_arch: x64, gh_suffix: "" }
+          - { os: linux, arch: arm64, host_arch: arm64, gh_suffix: "-arm" }
     needs:
       - lint
       - build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,9 +85,9 @@ jobs:
         run: |
           {
             echo END_OF_LIFE="$(date -d "+ 5 years" "+%Y-%m-%d")"
-            echo POSTGRESQL_MAJOR_VERSION="$(yq --raw-output '.version | split(".")[0]' rockcraft.yaml)"
-            echo POSTGRESQL_MINOR_VERSION="$(yq --raw-output '.version | split(".")[1]' rockcraft.yaml)"
-            echo OS_VERSION="$(yq --raw-output '.base | split("@")[1]' rockcraft.yaml)"
+            echo POSTGRESQL_MAJOR_VERSION="$(yq '.version | split(".")[0]' rockcraft.yaml)"
+            echo POSTGRESQL_MINOR_VERSION="$(yq '.version | split(".")[1]' rockcraft.yaml)"
+            echo OS_VERSION="$(yq '.base | split("@")[1]' rockcraft.yaml)"
           } >> "${GITHUB_ENV}"
       - name: Release
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,10 +83,12 @@ jobs:
           echo OCI_FACTORY="$(go env GOPATH)/bin/oci-factory" >> "${GITHUB_ENV}"
       - name: Set image version to environment
         run: |
-          echo END_OF_LIFE=$(date -d "+ 5 years" "+%Y-%m-%d") >> "${GITHUB_ENV}"
-          echo POSTGRESQL_MAJOR_VERSION=$(yq --raw-output '.version | split(".")[0]' rockcraft.yaml) >> "${GITHUB_ENV}"
-          echo POSTGRESQL_MINOR_VERSION=$(yq --raw-output '.version | split(".")[1]' rockcraft.yaml) >> "${GITHUB_ENV}"
-          echo OS_VERSION=$(yq --raw-output '.base | split("@")[1]' rockcraft.yaml) >> "${GITHUB_ENV}"
+          {
+            echo END_OF_LIFE=$(date -d "+ 5 years" "+%Y-%m-%d")
+            echo POSTGRESQL_MAJOR_VERSION=$(yq --raw-output '.version | split(".")[0]' rockcraft.yaml)
+            echo POSTGRESQL_MINOR_VERSION=$(yq --raw-output '.version | split(".")[1]' rockcraft.yaml)
+            echo OS_VERSION=$(yq --raw-output '.base | split("@")[1]' rockcraft.yaml)
+          } >> "${GITHUB_ENV}"
       - name: Release
         run: |
           "${OCI_FACTORY}" upload -y --release \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,13 +15,13 @@ on:
 jobs:
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v32.2.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v32.2.2
 
   release:
     name: Release rock
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v32.2.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v32.2.2
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,10 +84,10 @@ jobs:
       - name: Set image version to environment
         run: |
           {
-            echo END_OF_LIFE=$(date -d "+ 5 years" "+%Y-%m-%d")
-            echo POSTGRESQL_MAJOR_VERSION=$(yq --raw-output '.version | split(".")[0]' rockcraft.yaml)
-            echo POSTGRESQL_MINOR_VERSION=$(yq --raw-output '.version | split(".")[1]' rockcraft.yaml)
-            echo OS_VERSION=$(yq --raw-output '.base | split("@")[1]' rockcraft.yaml)
+            echo END_OF_LIFE="$(date -d "+ 5 years" "+%Y-%m-%d")"
+            echo POSTGRESQL_MAJOR_VERSION="$(yq --raw-output '.version | split(".")[0]' rockcraft.yaml)"
+            echo POSTGRESQL_MINOR_VERSION="$(yq --raw-output '.version | split(".")[1]' rockcraft.yaml)"
+            echo OS_VERSION="$(yq --raw-output '.base | split("@")[1]' rockcraft.yaml)"
           } >> "${GITHUB_ENV}"
       - name: Release
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,16 +80,16 @@ jobs:
           go install github.com/canonical/oci-factory/tools/cli-client/cmd/oci-factory@latest
       - name: Set binary paths to environment
         run: |
-          echo OCI_FACTORY=$(go env GOPATH)/bin/oci-factory >> $GITHUB_ENV
+          echo OCI_FACTORY="$(go env GOPATH)/bin/oci-factory" >> "${GITHUB_ENV}"
       - name: Set image version to environment
         run: |
-          echo END_OF_LIFE=$(date -d "+ 5 years" "+%Y-%m-%d") >> $GITHUB_ENV
-          echo POSTGRESQL_MAJOR_VERSION=$(yq --raw-output '.version | split(".")[0]' rockcraft.yaml) >> $GITHUB_ENV
-          echo POSTGRESQL_MINOR_VERSION=$(yq --raw-output '.version | split(".")[1]' rockcraft.yaml) >> $GITHUB_ENV
-          echo OS_VERSION=$(yq --raw-output '.base | split("@")[1]' rockcraft.yaml) >> $GITHUB_ENV
+          echo END_OF_LIFE=$(date -d "+ 5 years" "+%Y-%m-%d") >> "${GITHUB_ENV}"
+          echo POSTGRESQL_MAJOR_VERSION=$(yq --raw-output '.version | split(".")[0]' rockcraft.yaml) >> "${GITHUB_ENV}"
+          echo POSTGRESQL_MINOR_VERSION=$(yq --raw-output '.version | split(".")[1]' rockcraft.yaml) >> "${GITHUB_ENV}"
+          echo OS_VERSION=$(yq --raw-output '.base | split("@")[1]' rockcraft.yaml) >> "${GITHUB_ENV}"
       - name: Release
         run: |
-          $OCI_FACTORY upload -y --release \
-            track=${POSTGRESQL_MAJOR_VERSION}.${POSTGRESQL_MINOR_VERSION}-${OS_VERSION},eol=${END_OF_LIFE},risks=edge
+          "${OCI_FACTORY}" upload -y --release \
+            track="${POSTGRESQL_MAJOR_VERSION}.${POSTGRESQL_MINOR_VERSION}-${OS_VERSION},eol=${END_OF_LIFE},risks=edge"
         env:
           GITHUB_TOKEN: ${{ secrets.DP_BOT_PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,8 +85,8 @@ jobs:
         run: |
           {
             echo END_OF_LIFE="$(date -d "+ 5 years" "+%Y-%m-%d")"
-            echo POSTGRESQL_MAJOR_VERSION="$(yq '.version | split(".")[0]' rockcraft.yaml)"
-            echo POSTGRESQL_MINOR_VERSION="$(yq '.version | split(".")[1]' rockcraft.yaml)"
+            echo POSTGRESQL_MAJOR_VERSION="$(yq '(.version | tostring) | split(".")[0]' rockcraft.yaml)"
+            echo POSTGRESQL_MINOR_VERSION="$(yq '(.version | tostring) | split(".")[1]' rockcraft.yaml)"
             echo OS_VERSION="$(yq '.base | split("@")[1]' rockcraft.yaml)"
           } >> "${GITHUB_ENV}"
       - name: Release

--- a/README.md
+++ b/README.md
@@ -11,16 +11,15 @@ If you are using another version of Ubuntu or another operating system, the proc
 
 ### Clone Repository
 ```bash
-git clone git@github.com:canonical/postgresql-rock.git
+git clone https://github.com/canonical/postgresql-rock.git
 cd postgresql-rock
 ```
 
 ### Installing Prerequisites
 ```bash
-sudo snap install rockcraft --edge
+sudo snap install rockcraft --classic --edge
 sudo snap install docker
 sudo snap install lxd
-sudo snap install skopeo --edge --devmode
 ```
 
 ### Configuring Prerequisites
@@ -29,13 +28,40 @@ sudo usermod -aG docker $USER
 sudo lxd init --auto
 ```
 
-*_NOTE:_* You will need to open a new shell for the group change to take effect (i.e. `su - $USER`)
-
 ### Packing and Running the rock
 ```bash
+VERSION=$(awk '/^version: /{print $2;exit}' rockcraft.yaml)
 rockcraft pack
-sudo skopeo --insecure-policy copy oci-archive:postgresql*.rock docker-daemon:<username>/postgresql:<tag>
-docker run --rm -it <username>/postgresql-server:<tag>
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:postgres_${VERSION}_amd64.rock docker-daemon:${USER}/postgres:${VERSION}
+docker run --rm -it -e POSTGRES_PASSWORD=myS3cr3tp@ss -p 3432:5432 --name mypostgres ${USER}/postgres:${VERSION}
+```
+
+### Connecting to PostgreSQL
+From inside the container:
+```bash
+docker exec -it -e PGPASSWORD=myS3cr3tp@ss mypostgres psql -h 127.0.0.1 -p 5432 -U postgres -d postgres
+```
+
+From outside the container:
+```bash
+PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres
+```
+
+Troubleshooting:
+```bash
+docker exec -it mypostgres pebble logs
+docker exec -it mypostgres pebble services
+docker exec -it mypostgres pebble restart postgres
+```
+
+### Testing rock
+Using [Spread](https://github.com/canonical/spread):
+```bash
+rockcraft test                       # run all tests
+ls -la spread/tests/                 # list all tests
+rockcraft test -- spread/tests/smoke # run one test suite
+rockcraft test --debug               # to open shell for failed test
+rockcraft test --shell-after         # to open shell after each step
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sudo lxd init --auto
 VERSION=$(awk '/^version: /{print $2;exit}' rockcraft.yaml)
 rockcraft pack
 sudo rockcraft.skopeo --insecure-policy copy oci-archive:postgres_${VERSION}_amd64.rock docker-daemon:${USER}/postgres:${VERSION}
-docker run --rm -it -e POSTGRES_PASSWORD=myS3cr3tp@ss -p 3432:5432 --name mypostgres ${USER}/postgres:${VERSION}
+docker run --rm -it -e POSTGRES_PASSWORD=myS3cr3tp@ss -p 3432:5432 --name mypostgres --volume pg-data:/var/lib/postgresql/ -d ${USER}/postgres:${VERSION}
 ```
 
 ### Connecting to PostgreSQL

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ docker exec -it -e PGPASSWORD=myS3cr3tp@ss mypostgres psql -h 127.0.0.1 -p 5432 
 
 From outside the container:
 ```bash
+sudo apt install -y postgresql-client-*
 PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres
 ```
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: postgres
 base: ubuntu@24.04
-version: '16.9'
+version: 16.9
 summary: PostgreSQL rock OCI
 description: |
     PostgreSQL built from the official PostgreSQL Ubuntu apt package.
@@ -11,8 +11,9 @@ platforms:
     arm64:
 
 environment:
-    TZ: UTC
     PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/16/bin"
+    PGDATA: /var/lib/postgresql/data
+    TZ: UTC
 
 services:
     postgres:
@@ -60,6 +61,8 @@ parts:
             chown -R 584788 $CRAFT_PRIME/var/run/postgresql
             # Docker entrypoint compatibility
             mkdir -p $CRAFT_PRIME/docker-entrypoint-initdb.d/
+            # Allow access to PostgreSQL
+            sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" $CRAFT_PRIME/usr/share/postgresql/16/postgresql.conf.sample
             # Generate dpkg.query
             mkdir -p $CRAFT_PRIME/usr/share/rocks
             echo "# os-release" > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,38 @@
+project: postgres-rock
+
+backends:
+  craft:
+    type: craft
+    systems:
+      - ubuntu-24.04
+
+suites:
+  spread/tests/:
+    summary: General integration tests
+
+    prepare: |
+      # For 'rockcraft.skopeo'
+      snap install rockcraft --classic --edge
+      snap install docker
+
+      # Wait for docker daemon to come online
+      apt install -y retry
+      retry --times=10 --delay 2 -- docker run hello-world
+
+      # Load the rock into docker
+      rockcraft.skopeo --insecure-policy copy "oci-archive:$CRAFT_ARTIFACT" docker-daemon:postgres:spreadtest
+
+      # Install postgresql client (psql)
+      apt install -y postgresql-common postgresql-client-16
+    prepare-each: |
+      docker run -d --rm -e POSTGRES_PASSWORD=myS3cr3tp@ss -p 3432:5432 --name spreadlocaltest postgres:spreadtest
+      sleep 3 # Wait for pebble to bootstrap and launch Postgres
+    restore-each: |
+      docker kill spreadlocaltest || true
+    restore: |
+      docker image rm --force postgres:spreadtest
+
+exclude:
+  - .git
+
+kill-timeout: 1h

--- a/spread.yaml
+++ b/spread.yaml
@@ -23,10 +23,10 @@ suites:
       rockcraft.skopeo --insecure-policy copy "oci-archive:$CRAFT_ARTIFACT" docker-daemon:postgres:spreadtest
 
       # Install postgresql client (psql)
-      apt install -y postgresql-common postgresql-client-16
+      apt install -y postgresql-client-*
     prepare-each: |
       docker run -d --rm -e POSTGRES_PASSWORD=myS3cr3tp@ss -p 3432:5432 --name spreadlocaltest postgres:spreadtest
-      sleep 3 # Wait for pebble to bootstrap and launch Postgres
+      sleep 5 # Wait for pebble to bootstrap and launch Postgres
     restore-each: |
       docker kill spreadlocaltest || true
     restore: |

--- a/spread/.extension
+++ b/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | grep ",$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -1,0 +1,24 @@
+summary: PostgreSQL rock smoke tests
+
+execute: |
+  echo "Running smoke test..."
+
+  echo "Connecting DB..."
+  PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c "select now();"
+
+  echo "Connection DB with wrong credentials..."
+  PGPASSWORD=wrongpassord psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c "select now();" && exit 1 || true # failure expected
+
+  echo "Checking Pebble UI..."
+  docker exec -t spreadlocaltest pebble stop postgres
+  PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c "select now();" && exit 1 || true # failure expected
+
+  docker exec -t spreadlocaltest pebble start postgres
+  PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c "select now();"
+
+  docker exec -t spreadlocaltest pebble restart postgres
+  PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c "select now();"
+
+  docker exec -t spreadlocaltest pebble logs
+  docker exec -t spreadlocaltest pebble services
+


### PR DESCRIPTION
* add backward compatibility with legacy OCI and official DockerHub image
* add spread-based test using `rockctraft test`
* add `rockctraft test` to CI
* use Lint CI from data-platform-workflows
* update readme with more examples