### PR TITLE
DPE-7166: Add renovate + spread versions test

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>canonical/data-platform//renovate_presets/charm.json5"],
+  "reviewers": ["team:data-postgresql"],
+  "baseBranches": ["/^*-*\\.04$/"],
+}

--- a/spread.yaml
+++ b/spread.yaml
@@ -25,10 +25,10 @@ suites:
       # Install postgresql client (psql)
       apt install -y postgresql-client-*
     prepare-each: |
-      docker run -d --rm -e POSTGRES_PASSWORD=myS3cr3tp@ss -p 3432:5432 --name spreadlocaltest postgres:spreadtest
+      docker run -d --rm -e POSTGRES_PASSWORD=myS3cr3tp@ss -p 3432:5432 --name "${SPREAD_TASK//\//_}" postgres:spreadtest
       sleep 5 # Wait for pebble to bootstrap and launch Postgres
     restore-each: |
-      docker kill spreadlocaltest || true
+      docker kill "${SPREAD_TASK//\//_}" || true
     restore: |
       docker image rm --force postgres:spreadtest
 

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -10,15 +10,15 @@ execute: |
   PGPASSWORD=wrongpassord psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c "select now();" && exit 1 || true # failure expected
 
   echo "Checking Pebble UI..."
-  docker exec -t spreadlocaltest pebble stop postgres
+  docker exec -t "${SPREAD_TASK//\//_}" pebble stop postgres
   PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c "select now();" && exit 1 || true # failure expected
 
-  docker exec -t spreadlocaltest pebble start postgres
+  docker exec -t "${SPREAD_TASK//\//_}" pebble start postgres
   PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c "select now();"
 
-  docker exec -t spreadlocaltest pebble restart postgres
+  docker exec -t "${SPREAD_TASK//\//_}" pebble restart postgres
   PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c "select now();"
 
-  docker exec -t spreadlocaltest pebble logs
-  docker exec -t spreadlocaltest pebble services
+  docker exec -t "${SPREAD_TASK//\//_}" pebble logs
+  docker exec -t "${SPREAD_TASK//\//_}" pebble services
 

--- a/spread/tests/versions/task.yaml
+++ b/spread/tests/versions/task.yaml
@@ -1,0 +1,8 @@
+summary: PostgreSQL rock smoke tests
+
+execute: |
+  echo "Running versions test..."
+
+  ROCK_VERSION="$(awk '/^version: /{print $2;exit}' "${SPREAD_PATH}"/rockcraft.yaml)"
+  PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c "select version();" | MATCH "PostgreSQL ${ROCK_VERSION}"
+


### PR DESCRIPTION
Issue:

* there were no renovate config to update codebase
* there were no test to make sure the rock/rockcraft version matches workload version
* adding the second test created naming conflict

Solution:

* add renovate config
* add spread test to ensure rock version matches workload
* fixed the docker container naming conflict