### PR TITLE
DPE-8584 Update APT metadata before installing PostgreSQL

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,12 +86,11 @@ jobs:
           {
             echo END_OF_LIFE="$(date -d "+ 5 years" "+%Y-%m-%d")"
             echo POSTGRESQL_MAJOR_VERSION="$(yq '(.version | tostring) | split(".")[0]' rockcraft.yaml)"
-            echo POSTGRESQL_MINOR_VERSION="$(yq '(.version | tostring) | split(".")[1]' rockcraft.yaml)"
             echo OS_VERSION="$(yq '.base | split("@")[1]' rockcraft.yaml)"
           } >> "${GITHUB_ENV}"
       - name: Release
         run: |
           "${OCI_FACTORY}" upload -y --release \
-            track="${POSTGRESQL_MAJOR_VERSION}.${POSTGRESQL_MINOR_VERSION}-${OS_VERSION},eol=${END_OF_LIFE},risks=edge"
+            track="${POSTGRESQL_MAJOR_VERSION}-${OS_VERSION},eol=${END_OF_LIFE},risks=edge"
         env:
           GITHUB_TOKEN: ${{ secrets.DP_BOT_PAT }}

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -24,6 +24,13 @@ services:
         group: postgres
 
 parts:
+    apt:
+      plugin: nil
+      override-build: |
+        apt update
+        apt -y upgrade
+        apt -y dist-upgrade
+        craftctl default
     postgres:
         plugin: nil
         stage-packages:


### PR DESCRIPTION
Otherwise noble-update packages (security fixes) will not be use, the packages from noble will be chosen.

Also fix the major version tagging for PostgreSQL ROCK. The minor patches bump should keep the old tagging to follow historical logic of Ubuntu docker OCIs tagging.

Fixes: https://warthogs.atlassian.net/browse/DPE-8584