### PR TITLE
DPE-9018 Bump PostgreSQL 16.11

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: postgres
 base: ubuntu@24.04
-version: '16.10'
+version: '16.11'
 summary: PostgreSQL rock OCI
 description: |
     PostgreSQL built from the official PostgreSQL Ubuntu apt package.


### PR DESCRIPTION
The new PostgreSQL 16.11 has been released, bumping PostgreSQL slim snap.