### PR TITLE
fix(16-24.04): remove gosu as it is not required

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -37,7 +37,6 @@ parts:
             - pre-postgres
         overlay-packages:
             - coreutils
-            - gosu
             # set PG pager for psql to less
             - less
             - locales-all
@@ -52,7 +51,6 @@ parts:
             craftctl default
             mkdir -p $CRAFT_OVERLAY/licenses
             mv $CRAFT_OVERLAY/usr/share/doc/coreutils/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-coreutils
-            mv $CRAFT_OVERLAY/usr/share/doc/gosu/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-gosu
             mv $CRAFT_OVERLAY/usr/share/doc/less/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-less
             mv $CRAFT_OVERLAY/usr/share/doc/locales-all/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-locales-all
             mv $CRAFT_OVERLAY/usr/share/doc/postgresql/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-postgresql

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -311,10 +311,6 @@ _main() {
 		docker_setup_env
 		# setup data directories and permissions (when run as root)
 		docker_create_db_directories
-		if [ "$(id -u)" = '0' ]; then
-			# then restart script as postgres user
-			exec gosu postgres "$BASH_SOURCE" "$@"
-		fi
 
 		# only run initialization on an empty data directory
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then


### PR DESCRIPTION
### Description

`gosu` comes from `universe`, which enforces this to be a `pro` rock. However, `gosu` is not really required, since `pebble` is already running with `user: postgres` and `group: postgres`.

I verified this by making this change to the rock:

```yaml
services:
    postgres:
        override: replace
        command: sh -c "echo $(whoami && id -u)"
        startup: enabled
        user: postgres
        group: postgres
```

Then I ran the rock:
```
$ docker run --rm -d --name pg  postgres:16.11
15243470ff001c1d910f94141d9cb0eb712f176922fa1c01bc821e39a0a51b06
```

And got this output from the logs:
```
$ docker exec pg pebble logs postgres         
2026-02-19T18:33:36.402Z [postgres] postgres 584788
2026-02-19T18:33:36.955Z [postgres] postgres 584788
2026-02-19T18:33:37.977Z [postgres] postgres 584788
```

This means that the `entrypoint.sh` service is already being run as `postgres`, so the condition `if [ "$(id -u)" = '0' ]` is never `true` and can be removed all along.

#### Is the rock rootless then?
By the letter of the law, **No**, the rock is not rootless as the `root` user still exists. In fact, `pebble` is running as `root`, but the service running `postgres` is non-root. Note that this preserves the exact same behaviour as using `gosu`.

### Forward Porting
WIP