### PR TITLE
DPE-7166 Switch from gosu to sudo(-rs) to decrease Go CVEs impact

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -37,7 +37,7 @@ parts:
             - pre-postgres
         overlay-packages:
             - coreutils
-            - gosu
+            - sudo
             # set PG pager for psql to less
             - less
             - locales-all
@@ -52,7 +52,7 @@ parts:
             craftctl default
             mkdir -p $CRAFT_OVERLAY/licenses
             mv $CRAFT_OVERLAY/usr/share/doc/coreutils/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-coreutils
-            mv $CRAFT_OVERLAY/usr/share/doc/gosu/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-gosu
+            mv $CRAFT_OVERLAY/usr/share/doc/sudo/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-sudo
             mv $CRAFT_OVERLAY/usr/share/doc/less/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-less
             mv $CRAFT_OVERLAY/usr/share/doc/locales-all/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-locales-all
             mv $CRAFT_OVERLAY/usr/share/doc/postgresql/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-postgresql

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -313,7 +313,7 @@ _main() {
 		docker_create_db_directories
 		if [ "$(id -u)" = '0' ]; then
 			# then restart script as postgres user
-			exec gosu postgres "$BASH_SOURCE" "$@"
+			exec sudo -u postgres "$BASH_SOURCE" "$@"
 		fi
 
 		# only run initialization on an empty data directory


### PR DESCRIPTION
Otherwise it is impossible to pass oci-factory on-boarding:
https://github.com/canonical/oci-factory/actions/runs/22191361620/job/64181241590?pr=551#step:8:238
```
> # Golang CVE fixed in upstream PR
> # https://go-review.googlesource.com/c/go/+/578375
> # Patched version released in Ubuntu archive
> # https://ubuntu.com/security/CVE-2024-24788
> CVE-2024-24788
>
> # Golang CVE fixed in upstream PR
> # https://go-review.googlesource.com/c/go/+/590296
> # Patched version released in Ubuntu archive
> # https://ubuntu.com/security/CVE-2024-24790
> CVE-2024-24790
>
> # Golang CVE fixed in upstream PR
> # https://go-review.googlesource.com/c/go/+/611239
> # Patched version released in Ubuntu archive
> # https://ubuntu.com/security/CVE-2024-34156
> CVE-2024-34156
> Running Trivy with options: trivy image test-img:test
```