### PR TITLE
[DPE-7166] Fix oci release to avoid unnecessary quotes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,8 +88,8 @@ jobs:
         run: |
           {
             echo END_OF_LIFE="$(date -d "+ 5 years" "+%Y-%m-%d")"
-            echo POSTGRESQL_MAJOR_VERSION="$(yq '(.version | tostring) | split(".")[0]' rockcraft.yaml)"
-            echo OS_VERSION="$(yq '.base | split("@")[1]' rockcraft.yaml)"
+            echo POSTGRESQL_MAJOR_VERSION="$(yq -r '(.version | tostring) | split(".")[0]' rockcraft.yaml)"
+            echo OS_VERSION="$(yq -r '.base | split("@")[1]' rockcraft.yaml)"
           } >> "${GITHUB_ENV}"
       - name: Release
         run: |


### PR DESCRIPTION
# Issue:

Error on oci-factory CI/CD: https://github.com/canonical/oci-factory/actions/runs/22230081967/job/64310269112

> level=fatal msg="Invalid destination name docker://docker.io/ubuntu/postgres:\"16\"-\"24.04\"_edge: invalid reference format"

# Solution:

Partially revert 60174be25845e5f794a8732231bfab1d7e73dee6 to print yq output in RAW.