### PR TITLE
[DPE-9455] Bump PostgreSQL to 16.13

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: postgres
 base: ubuntu@24.04
-version: '16.11'
+version: '16.13'
 summary: PostgreSQL rock OCI
 description: |
     PostgreSQL built from the official PostgreSQL Ubuntu apt package.


### PR DESCRIPTION
# Issue:

We ship outdated PostgreSQL 16.11.

# Solution:

Update PostgreSQL to 16.13.