### PR TITLE
Add zizmor and update dpw to v48

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,15 +15,36 @@ on:
         description: build_rock.yaml `artifact-prefix` output
         value: ${{ jobs.build.outputs.artifact-prefix }}
 
-permissions: {}
 jobs:
+  lint-workflows:
+    name: Lint .github/workflows/
+    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v48.0.4
+    permissions:
+      contents: read
+
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v42.0.1
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install tox & poetry
+        run: |
+          pipx install tox
+          pipx install poetry
+      - name: tox run -e lint
+        run: tox run -e lint
+    permissions: {}
 
   build:
     name: Build rock
-    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v42.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v48.0.4
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 
   test:
     name: Test rock | ${{ matrix.base.version }} ${{ matrix.platform.arch }}
@@ -44,6 +65,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download rock package(s)
         uses: actions/download-artifact@v8
         with:
@@ -63,3 +86,4 @@ jobs:
 
           sudo snap install rockcraft --classic --edge
           sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- rockcraft test
+    permissions: {}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
           - { os: linux, arch: amd64, host_arch: x64, gh_suffix: "" }
           - { os: linux, arch: arm64, host_arch: arm64, gh_suffix: "-arm" }
     needs:
+      - lint-workflows
       - lint
       - build
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,16 +15,19 @@ jobs:
   ci-tests:
     name: Tests
     uses: ./.github/workflows/ci.yaml
-    permissions: {}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 
   release:
     name: Release rock
     needs:
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_rock.yaml@v42.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_rock_edge.yaml@v48.0.4
     with:
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
       packages: write  # Needed to publish to GitHub Container Registry
       contents: write  # Needed to create git tags
 
@@ -33,10 +36,14 @@ jobs:
     needs:
       - release
     runs-on: ubuntu-latest
-    permissions: {}
+    environment:
+      name: oci-factory
+      deployment: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Golang setup
         uses: actions/setup-go@v6
         with:
@@ -63,7 +70,8 @@ jobs:
           "${OCI_FACTORY}" upload -y --release \
             track="${POSTGRESQL_MAJOR_VERSION}-${OS_VERSION},eol=${END_OF_LIFE},risks=edge"
         env:
-          GITHUB_TOKEN: ${{ secrets.DP_BOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.DP_BOT_PAT_OCI_FACTORY }}
+    permissions: {}
 
   sbom:
     name: Generate Software Bill of Materials
@@ -73,10 +81,13 @@ jobs:
       - release
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions: {}
     steps:
       - name: Install Syft
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+        run: |
+          gh release --repo anchore/syft download --pattern '*_linux_amd64.deb' --output syft.deb
+          sudo apt-get install -y ./syft.deb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download rock package(s)
         uses: actions/download-artifact@v8
         with:
@@ -99,11 +110,13 @@ jobs:
           name: sbom-${{ needs.ci-tests.outputs.artifact-prefix }}
           path: '*.spdx.json'
           if-no-files-found: error
+    permissions: {}
+
   trivy:
     needs:
       # Checks the pushed tag
       - release
-    permissions:
-      security-events: write  # Required for uploading Trivy SARIF results
     name: Trivy Scan
     uses: ./.github/workflows/trivy.yaml
+    permissions:
+      security-events: write  # Required for uploading Trivy SARIF results

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -6,9 +6,6 @@ on:
   # Dispatched by scheduler
   workflow_dispatch:
 
-permissions:
-  security-events: write  # Required for uploading Trivy SARIF results
-
 jobs:
   scan:
     name: Trivy scan
@@ -16,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install required dependencies
         run: |
           # rockcraft
@@ -38,3 +37,5 @@ jobs:
         if: always()
         with:
           sarif_file: "trivy-results.sarif"
+    permissions:
+      security-events: write  # Required for uploading Trivy SARIF results

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,35 @@
+rules:
+  # Allowlist trusted actions
+  forbidden-uses:
+    config:
+      # Actions in this list have remote code execution in our workflows. Even if the workflow has
+      # limited permissions, those can be escaped. See https://github.com/AdnaneKhan/Cacheract and
+      # "But Wait, There’s More" section of
+      # https://www.praetorian.com/blog/codeqleaked-public-secrets-exposure-leads-to-supply-chain-attack-on-github-codeql/
+      # In general, this list should be limited to organizations that we trust to have a baseline
+      # level of operational security. Avoid adding actions that could be replaced with a few lines
+      # of bash.
+      allow:  # Get approval from your manager before adding actions to this list.
+        - canonical/*
+        - actions/*
+        - docker/login-action
+        - tiobe/tics-github-action
+        - aquasecurity/trivy-action
+        - github/codeql-action/upload-sarif
+  # Pinning actions to a commit SHA has a security tradeoff—pinned actions cannot be later
+  # compromised, but they also cannot be security patched.
+  # Above (in `forbidden-uses`), we restrict actions usage to organizations that we trust to have
+  # a baseline level of operational security.
+  # Our actions usage involves several long-term support branches and reusable workflows (which
+  # themselves use actions). For our threat model, we believe it is safer to limit actions usage to
+  # organizations we trust and immediately receive security patching across our many branches than
+  # it is to pin actions to a commit SHA.
+  unpinned-uses:
+    config:
+      policies:
+        canonical/*: ref-pin
+        actions/*: ref-pin
+        docker/login-action: ref-pin
+        tiobe/tics-github-action: ref-pin
+        aquasecurity/trivy-action: ref-pin
+        github/codeql-action/upload-sarif: ref-pin


### PR DESCRIPTION
https://discourse.canonical.com/t/security-update-action-requested/7120

After this PR is merged, the following secret actions will be required:
- Revoke and delete these secrets:
  ```
  DP_BOT_PAT
  ```
- Create these secrets (new credentials) for the `oci-factory` environment (do **not** add as repository secrets)
  ```
  DP_BOT_PAT_OCI_FACTORY
  ```
    - Use fine-grained token with limited scopes