### PR TITLE
fix(16-24.04): run service command outside sh -c

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -18,7 +18,7 @@ environment:
 services:
     postgres:
         override: replace
-        command: sh -c "/usr/local/bin/entrypoint.sh postgres"
+        command: /usr/local/bin/entrypoint.sh postgres
         startup: enabled
         user: postgres
         group: postgres


### PR DESCRIPTION
You currently define the service command as follows:

```yaml
command: sh -c "/usr/local/bin/entrypoint.sh postgres"
```

When you pass anything via `--args` it would be running:

```
sh -c "/usr/local/bin/entrypoint.sh postgres" <args>
```

So those args are never being passed to the entrypoint because it's inside `sh -c`

You can fix this by directly calling the entrypoint, as this PR proposes.

---

### Quick test

```
$ docker run --rm --name pg-test -d -e POSTGRES_PASSWORD=test postgres:16.13 --args postgres -c max_connections=300
2bda0a0eed29ea2fdc292707a806abe4b32c348e6c90187ea140b58012e4f85a
```

```
$ docker exec -it -e PGPASSWORD=test pg-test psql -h 127.0.0.1 -p 5432 -U postgres -c 'show max_connections'
 max_connections 
-----------------
 300
(1 row)
```

---

### Notes

Your current `entrypoint.sh` file accepts other commands aside from `postgres`, i.e `/bin/bash`. You can make this work by modifying the service command as follows:

```yaml
command: /usr/local/bin/entrypoint.sh [ postgres ]
```

By encapsulating `postgres` within brackets, you are telling pebble that it can be overridden via `--args`. However, IMO this is rather misleading, since `postgres` is a PEBBLE SERVICE, so the entrypoint should only run such service and no other binary.

If one wanted to run another binary within the rock, it should be done via `docker exec ... <command>`, and not through a service.

---

### Forwards ports:

* #81 
* #82 