### PR TITLE
[DPE-10781] Restore the complete compatibility with official Docker OCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,10 @@ docker run -it -d \
     --name mypostgres \
     --volume pg-data:/var/lib/postgresql/ \
     ubuntu/postgres:16-24.04_edge \
-        --args postgres \
-            -c max_connections=242 \
-            -c fsync=off \
-            -c full_page_writes=off \
-            -c shared_buffers=256MB
+        -c max_connections=242 \
+        -c fsync=off \
+        -c full_page_writes=off \
+        -c shared_buffers=256MB
 
 
 docker exec -it -e PGPASSWORD=myS3cr3tp@ss mypostgres \

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: postgres
 base: ubuntu@24.04
-version: '16.14'
+version: '16.15'
 summary: PostgreSQL rock OCI
 description: |
     PostgreSQL built from the official PostgreSQL Ubuntu apt package.
@@ -15,10 +15,11 @@ environment:
     PGDATA: /var/lib/postgresql/data
     TZ: UTC
 
+entrypoint-service: postgres
 services:
     postgres:
         override: replace
-        command: /usr/local/bin/entrypoint.sh postgres
+        command: /usr/local/bin/entrypoint.sh [ postgres ]
         startup: enabled
         user: postgres
         group: postgres

--- a/spread/tests/config/task.yaml
+++ b/spread/tests/config/task.yaml
@@ -1,0 +1,21 @@
+summary: PostgreSQL rock config tests
+
+execute: |
+  echo "Running smoke test..."
+
+  echo "Checking default max_connections..."
+  PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c 'show max_connections;' | grep 100
+  PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c 'show shared_buffers;' | grep 128MB
+
+  echo "Stop/clean the container with default PG config..."
+  docker stop --timeout 0 "${SPREAD_TASK//\//_}"
+  docker rm "${SPREAD_TASK//\//_}" || true
+
+  echo "Staring container with non-default config..."
+  docker run -d --rm -e POSTGRES_PASSWORD=myS3cr3tp@ss -p 3432:5432 --name "${SPREAD_TASK//\//_}" postgres:spreadtest \
+    -c max_connections=242 -c fsync=off -c full_page_writes=off -c shared_buffers=256MB
+  sleep 5
+
+  echo "Checking non-default max_connections..."
+  PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c 'show max_connections;' | grep 242
+  PGPASSWORD=myS3cr3tp@ss psql -h 127.0.0.1 -p 3432 -U postgres -d postgres -c 'show shared_buffers;' | grep 256MB


### PR DESCRIPTION
## Issue 

PostgreSQL ROCK did require an extra parameter `--args postgres` due to Pebble inside:
```
docker run -it -d \
    ...
    ubuntu/postgres:16-24.04_edge \
        --args postgres \
            -c max_connections=242 \
            -c fsync=off \
            -c full_page_writes=off \
            -c shared_buffers=256MB
```

## Solution

The `entrypoint-service: postgres` allows to provide complete UI compatibility with official PostgreSQL docker image:
```
docker run -it -d \
    ...
    ubuntu/postgres:16-24.04_edge \
        -c max_connections=242 \
        -c fsync=off \
        -c full_page_writes=off \
        -c shared_buffers=256MB
```

It provides us drag&drop replacements capabilities.
